### PR TITLE
Fix 2d dx_arr and dy_arr: the do not need an extra dimension at creation

### DIFF
--- a/jwst_kpi/recenter_frames/recenter_frames_step.py
+++ b/jwst_kpi/recenter_frames/recenter_frames_step.py
@@ -284,12 +284,9 @@ class RecenterFramesStep(Step):
             output_models.dq_mod = input_models.dq_mod
         except AttributeError:
             self.log.warning("Could not pass bad pixel mask from BP step")
-        if is2d:
-            dx_arr = np.array([dx])  # pix
-            dy_arr = np.array([dy])  # pix
-        else:
-            dx_arr = np.array(dx)  # pix
-            dy_arr = np.array(dy)  # pix
+        dx_arr = np.array(dx)  # pix
+        dy_arr = np.array(dy)  # pix
+        # In recarray shape should be the length
         output_models.imshift = np.recarray(dx_arr.shape, output_models.imshift.dtype)
         output_models.imshift["XSHIFT"] = dx_arr
         output_models.imshift["YSHIFT"] = dy_arr


### PR DESCRIPTION
Another small PR: the dimension of 2D files is handled before the recenter function runs, so there is no need for an extra dimension when creating the file. I tested this on `cal.fits` files recently.